### PR TITLE
Fix issue with URI not being able to be parsed properly

### DIFF
--- a/service.go
+++ b/service.go
@@ -72,6 +72,10 @@ func getHostPort(uri string) (string, string, error) {
 		return "", "", err
 	}
 
+	if hostUrl.Host == "" {
+		return hostUrl.Scheme, hostUrl.Opaque, nil
+	}
+
 	sp := strings.Split(hostUrl.Host, ":")
 	if len(sp) != 2 {
 		return "", "", ErrInvalidHost


### PR DESCRIPTION
Aiven now returns <service-name>.<project>.aivencloud.com:<port> as the URI. According to this documentation, https://golang.org/pkg/net/url/#URL, only scheme and opaque will be filled in this scenario.