### PR TITLE
min_insync_replicas as int field (according to Aiven API specs)

### DIFF
--- a/kafka_topic.go
+++ b/kafka_topic.go
@@ -66,10 +66,10 @@ type (
 
 	// UpdateKafkaTopicRequest are the parameters used to update a kafka topic.
 	UpdateKafkaTopicRequest struct {
-		MinimumInSyncReplicas *int   `json:"min_insync_replicas,omitempty"`
-		Partitions            *int   `json:"partitions,omitempty"`
-		RetentionBytes        *int   `json:"retention_bytes,omitempty"`
-		RetentionHours        *int   `json:"retention_hours,omitempty"`
+		MinimumInSyncReplicas *int `json:"min_insync_replicas,omitempty"`
+		Partitions            *int `json:"partitions,omitempty"`
+		RetentionBytes        *int `json:"retention_bytes,omitempty"`
+		RetentionHours        *int `json:"retention_hours,omitempty"`
 	}
 
 	// KafkaTopicResponse is the response for Kafka Topic requests.

--- a/kafka_topic.go
+++ b/kafka_topic.go
@@ -66,7 +66,7 @@ type (
 
 	// UpdateKafkaTopicRequest are the parameters used to update a kafka topic.
 	UpdateKafkaTopicRequest struct {
-		MinimumInSyncReplicas string `json:"min_insync_replicas"`
+		MinimumInSyncReplicas *int   `json:"min_insync_replicas,omitempty"`
 		Partitions            *int   `json:"partitions,omitempty"`
 		RetentionBytes        *int   `json:"retention_bytes,omitempty"`
 		RetentionHours        *int   `json:"retention_hours,omitempty"`


### PR DESCRIPTION
The field was defined as string but the API specs define it as int and optional: https://api.aiven.io/doc/#api-Service__Kafka-ServiceKafkaTopicUpdate