### PR TITLE
Adds basic user-config field to service

### DIFF
--- a/service.go
+++ b/service.go
@@ -23,6 +23,7 @@ type (
 		State      string         `json:"state"`
 		Metadata   interface{}    `json:"metadata"`
 		Users      []*ServiceUser `json:"users"`
+		UserConfig interface{}    `json:"user_config"`
 	}
 
 	// ServicesHandler is the client that interacts with the Service API
@@ -33,11 +34,12 @@ type (
 
 	// CreateServiceRequest are the parameters to create a Service.
 	CreateServiceRequest struct {
-		Cloud       string `json:"cloud,omitempty"`
-		GroupName   string `json:"group_name,omitempty"`
-		Plan        string `json:"plan,omitempty"`
-		ServiceName string `json:"service_name"`
-		ServiceType string `json:"service_type"`
+		Cloud       string                 `json:"cloud,omitempty"`
+		GroupName   string                 `json:"group_name,omitempty"`
+		Plan        string                 `json:"plan,omitempty"`
+		ServiceName string                 `json:"service_name"`
+		ServiceType string                 `json:"service_type"`
+		UserConfig  map[string]interface{} `json:"user_config,omitempty"`
 	}
 
 	// UpdateServiceRequest are the parameters to update a Service.


### PR DESCRIPTION
@jelmersnoeck [Adds basic `user_config` to the service definition](https://api.aiven.io/doc/#api-Service-ServiceCreate) so that users can pass through additional database configuration. I abstained for now from adding checks b/c the aiven API will return errors on bad/unknown fields.