### PR TITLE
Fetch Project CA along with Project details

### DIFF
--- a/ca.go
+++ b/ca.go
@@ -1,0 +1,46 @@
+package aiven
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type (
+	// CAHandler is the client which interacts with the Projects CA endpoint
+	// on Aiven.
+	CAHandler struct {
+		client *Client
+	}
+
+	// ProjectCAResponse is the response from Aiven for project CA Certificate.
+	ProjectCAResponse struct {
+		APIResponse
+		CACertificate string `json:"certificate"`
+	}
+)
+
+// Get gets the specified Project CA Certificate
+func (h *CAHandler) Get(project string) (string, error) {
+	bts, err := h.client.doGetRequest("/project/"+project+"/kms/ca", nil)
+	if err != nil {
+		return "", err
+	}
+
+	if bts == nil {
+		return "", ErrNoResponseData
+	}
+
+	var rsp *ProjectCAResponse
+	if err := json.Unmarshal(bts, &rsp); err != nil {
+		return "", err
+	}
+
+	if rsp == nil {
+		return "", ErrNoResponseData
+	}
+
+	if rsp.Errors != nil && len(rsp.Errors) != 0 {
+		return "", errors.New(rsp.Message)
+	}
+	return rsp.CACertificate, nil
+}

--- a/client.go
+++ b/client.go
@@ -16,6 +16,7 @@ type Client struct {
 	Client *http.Client
 
 	Projects     *ProjectsHandler
+	CA           *CAHandler
 	Services     *ServicesHandler
 	Databases    *DatabasesHandler
 	ServiceUsers *ServiceUsersHandler
@@ -52,6 +53,7 @@ func NewTokenClient(key string) (*Client, error) {
 // Init initializes the client and sets up all the handlers.
 func (c *Client) Init() {
 	c.Projects = &ProjectsHandler{c}
+	c.CA = &CAHandler{c}
 	c.Services = &ServicesHandler{c}
 	c.Databases = &DatabasesHandler{c}
 	c.ServiceUsers = &ServiceUsersHandler{c}


### PR DESCRIPTION
@FranOis @jelmersnoeck 
Morning guys, this adds a feature to the project component so that we fetch CA Certificates when we grab project information. This will be useful for some of the Aiven clients that use TLS, since the CA will need to be specified so that users dont have to use insecure connections/blindly trust.